### PR TITLE
unionized contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,10 @@ Once the application is up and running, start to issue requests. Currently, the 
 To trigger a request against the __*identity*__ model, type the following:
 
 ```bash
-curl -v -X POST 0.0.0.0:8078/model/identity/index/0 -d '{"tensorType":{"ttype":0},"dimensions":[1,4],"data":[0,0,128,63,0,0,0,64,0,0,64,64,0,0,128,64]}'
+curl -v -X POST 0.0.0.0:8078/model/identity/index/0 -d '{"tensorType":{"F32":0},"dimensions":[1,4],"data":[0,0,128,63,0,0,0,64,0,0,64,64,0,0,128,64]}'
 ```
 
-The response should comprise `HTTP/1.1 200 OK` as well as `{"result":{"hasError":false},"tensor":{"tensorType":{"ttype":0},"dimensions":[1,4],"data":[0,0,128,63,0,0,0,64,0,0,64,64,0,0,128,64]}}`
+The response should comprise `HTTP/1.1 200 OK` as well as `{"result":{"hasError":false},"tensor":{"tensorType":{"F32":0},"dimensions":[1,4],"data":[0,0,128,63,0,0,0,64,0,0,64,64,0,0,128,64]}}`
 
 The following happens:
 
@@ -99,13 +99,13 @@ The following happens:
 To trigger a request against the __*plus3*__ model, type the following:
 
 ```bash
-curl -v -X POST 0.0.0.0:8078/model/plus3/index/0 -d '{"tensorType":{"ttype":0},"dimensions":[1,4],"data":[0,0,128,63,0,0,0,64,0,0,64,64,0,0,128,64]}'
+curl -v -X POST 0.0.0.0:8078/model/plus3/index/0 -d '{"tensorType":{"F32":0},"dimensions":[1,4],"data":[0,0,128,63,0,0,0,64,0,0,64,64,0,0,128,64]}'
 ```
 
 The response is
 
 ```bash
-{"result":{"hasError":false},"tensor":{"tensorType":{"ttype":0},"dimensions":[1,4],"data":[0,0,128,64,0,0,160,64,0,0,192,64,0,0,224,64]}}
+{"result":{"hasError":false},"tensor":{"tensorType":{"F32":0},"dimensions":[1,4],"data":[0,0,128,64,0,0,160,64,0,0,192,64,0,0,224,64]}}
 ```
 
 Note that in contrast to the __*identity*__ model, the answer from __*plus3*__ is not at all identical to the request. Converting the vector of bytes `[0,0,128,64,0,0,160,64,0,0,192,64,0,0,224,64]` back to a vector of `f32` yields `[4.0, 5.0, 6.0, 7.0]`. This was expected: each element from the input is incremented by three `[1.0, 2.0, 3.0, 4.0]` &rarr; `[4.0, 5.0, 6.0, 7.0]`, hence the name of the model: __*plus3*__.

--- a/interfaces/mlinference/mlinference.smithy
+++ b/interfaces/mlinference/mlinference.smithy
@@ -12,7 +12,7 @@ use org.wasmcloud.model#U8
 use org.wasmcloud.model#U16
 use org.wasmcloud.model#U32
 use org.wasmcloud.model#U64
-//use org.wasmcloud.model#F16
+use org.wasmcloud.model#F16
 use org.wasmcloud.model#F32
 use org.wasmcloud.model#I32
 
@@ -25,8 +25,8 @@ use org.wasmcloud.model#I32
 @wasmbus(
     contractId: "wasmcloud:example:mlinference",
     actorReceive: true,
-    providerReceive: true )
-//    protocol: "2" )
+    providerReceive: true,
+    protocol: "2" )
 
 service Mlinference {
   version: "0.1",
@@ -39,6 +39,7 @@ operation Predict {
   output: InferenceOutput
 }
 
+@codegenRust(noDeriveDefault: true, noDeriveEq: true)
 structure InferenceRequest {
   @required
   @n(0)
@@ -55,7 +56,7 @@ structure InferenceRequest {
 
 /// The tensor's dimensions and type are provided as metadata to a model.
 /// Any metadata shall be associated to the respective model in a blob store.
-//@codegenRust(noDeriveDefault: true, noDeriveEq: true)
+@codegenRust(noDeriveDefault: true, noDeriveEq: true)
 structure Tensor {
     @required
     @n(0)
@@ -74,55 +75,24 @@ list TensorDimensions {
   member: U32
 }
 
-// /// TensorType
-// union TensorType {
-//   //  @n(0)
-//   //  F16: F16,
-   
-//    @n(1)
-//    f32: F32,
-
-//    @n(2)
-//    u8: U8,
-
-//    @n(3)
-//    i32: I32
-// }
-
 /// TensorType
-structure TensorType {
-  // enum seems to have no impact on the code generator
-  @enum([
-    {
-      value: 0,
-      name: "TENSOR_TYPE_F16",
-      documentation: """TBD""",
-      tags: ["tensorType"]
-    },
-    {
-      value: 1,
-      name: "TENSOR_TYPE_F32",
-      documentation: """TBD""",
-      tags: ["tensorType"]
-    },
-    {
-      value: 2,
-      name: "TENSOR_TYPE_U8",
-      documentation: """TBD""",
-      tags: ["tensorType"]
-    },
-    {
-      value: 3,
-      name: "TENSOR_TYPE_I32",
-      documentation: """TBD""",
-      tags: ["tensorType"]
-    }
-  ])
-  @required
-  ttype: U8
+@codegenRust(noDeriveEq:true)
+union TensorType {
+  @n(0)
+  F16: U8,
+   
+   @n(1)
+   F32: U8,
+
+   @n(2)
+   U8: U8,
+
+   @n(3)
+   I32: U8,
 }
 
 /// InferenceOutput
+@codegenRust(noDeriveDefault: true, noDeriveEq: true)
 structure InferenceOutput {
   @required
   @n(0)
@@ -133,6 +103,7 @@ structure InferenceOutput {
   tensor: Tensor
 }
 
+@codegenRust(noDeriveEq:true)
 structure ResultStatus {
   @required
   @n(0)
@@ -142,79 +113,28 @@ structure ResultStatus {
   error: MlError
 }
 
-// union MlError {
-//   @n(0)
-//   invalidModel: U16,
+union MlError {
+  @n(0)
+  invalidModel: U16,
     
-//   @n(1)
-//   invalidEncoding: U16,
+  @n(1)
+  invalidEncoding: U16,
 
-//   @n(2)
-//   corruptInputTensor: U16,
+  @n(2)
+  corruptInputTensor: U16,
 
-//   @n(3)
-//   runtimeError: U16,
+  @n(3)
+  runtimeError: U16,
 
-//   @n(4)
-//   openVinoError: U16,
+  @n(4)
+  openVinoError: U16,
 
-//   @n(5)
-//   onnxError: U16,
+  @n(5)
+  onnxError: U16,
 
-//   @n(6)
-//   tensorflowError: U16,
+  @n(6)
+  tensorflowError: U16,
 
-//   @n(7)
-//   contextNotFoundError: U16
-// }
-
-
-structure MlError {
-  // enum seems to have no impact on the code generator
-  @enum([
-    {
-      value: 0,
-      name: "MODEL_ERROR",
-      documentation: """TBD""",
-      tags: ["MlInferenceError"]
-    },
-    {
-      value: 1,
-      name: "INVALID_ENCODING_ERROR",
-      documentation: """TBD""",
-      tags: ["MlInferenceError"]
-    },
-    {
-      value: 2,
-      name: "CORRUPT_INPUT_TENSOR",
-      documentation: """TBD""",
-      tags: ["MlInferenceError"]
-    },
-    {
-      value: 3,
-      name: "RUNTIME_ERROR",
-      documentation: """TBD""",
-      tags: ["MlInferenceError"]
-    },
-    {
-      value: 4,
-      name: "OPEN_VINO_ERROR",
-      documentation: """TBD""",
-      tags: ["MlInferenceError"]
-    },
-    {
-      value: 5,
-      name: "ONNX_ERROR",
-      documentation: """TBD""",
-      tags: ["MlInferenceError"]
-    },
-    {
-      value: 6,
-      name: "CONTEXT_NOT_FOUND",
-      documentation: """TBD""",
-      tags: ["MlInferenceError"]
-    },
-  ])
-  @required
-  err: U8
+  @n(7)
+  contextNotFoundError: U16
 }

--- a/providers/mlinference/src/inference/mod.rs
+++ b/providers/mlinference/src/inference/mod.rs
@@ -2,7 +2,7 @@ mod tract;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 pub use tract::{bytes_to_f32_vec, f32_vec_to_bytes, TractEngine, TractSession};
-use wasmcloud_interface_mlinference::{InferenceOutput, Tensor, TensorType};
+use wasmcloud_interface_mlinference::{InferenceOutput, Tensor};
 
 /// Graph (model number)
 pub type Graph = u32;
@@ -36,29 +36,6 @@ pub enum ExecutionTarget {
 impl Default for ExecutionTarget {
     fn default() -> Self {
         ExecutionTarget::Cpu
-    }
-}
-
-/// TensorType
-#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
-pub struct TType(pub u8);
-
-impl TType {
-    pub const F16: u8 = 0;
-    pub const F32: u8 = 1;
-    pub const U8: u8 = 2;
-    pub const I32: u8 = 3;
-}
-
-impl From<TensorType> for TType {
-    fn from(tt: TensorType) -> TType {
-        TType(tt.ttype)
-    }
-}
-
-impl From<TType> for TensorType {
-    fn from(tt: TType) -> TensorType {
-        TensorType { ttype: tt.0 }
     }
 }
 

--- a/providers/mlinference/src/inference/tract.rs
+++ b/providers/mlinference/src/inference/tract.rs
@@ -314,7 +314,7 @@ impl InferenceEngine for TractEngine {
                 error: None,
             },
             tensor: Tensor {
-                tensor_type: TensorType { ttype: 0 },
+                tensor_type: TensorType::F32(0),
                 dimensions: tensor
                     .shape()
                     .iter()

--- a/providers/mlinference/src/lib.rs
+++ b/providers/mlinference/src/lib.rs
@@ -9,7 +9,7 @@ pub use bindle_loader::{BindleLoader, ModelMetadata};
 pub mod inference;
 pub use inference::{
     bytes_to_f32_vec, f32_vec_to_bytes, ExecutionTarget, Graph, GraphEncoding,
-    GraphExecutionContext, InferenceEngine, TType, TractEngine,
+    GraphExecutionContext, InferenceEngine, TractEngine,
 };
 
 mod settings;

--- a/providers/mlinference/src/lib.rs
+++ b/providers/mlinference/src/lib.rs
@@ -22,26 +22,38 @@ pub type BindlePath = String;
 pub type ModelName = String;
 pub type ModelZoo = HashMap<ModelName, ModelContext>;
 
-#[derive(Clone, Debug, Default, PartialEq, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Deserialize)]
 pub struct ModelContext {
     pub bindle_url: BindlePath,
     pub graph_encoding: GraphEncoding,
     pub execution_target: ExecutionTarget,
-    pub tensor_type: TType,
+    pub tensor_type: TensorType,
     pub graph_execution_context: GraphExecutionContext,
     pub graph: Graph,
 }
 
 impl ModelContext {
+    pub fn default() -> ModelContext {
+        ModelContext {
+            bindle_url: Default::default(),
+            graph_encoding: Default::default(),
+            execution_target: Default::default(),
+            tensor_type: TensorType::F32(0),
+            graph_execution_context: Default::default(),
+            graph: Default::default(),
+        }
+    }
+    
+
     /// load metadata
     pub fn load_metadata(&mut self, metadata: ModelMetadata) -> Result<&ModelContext, Error> {
         self.graph_encoding = metadata.graph_encoding;
 
         self.tensor_type = match metadata.tensor_type.as_str() {
-            "F16" => Ok(TType(TType::F16)),
-            "F32" => Ok(TType(TType::F32)),
-            "U8"  => Ok(TType(TType::U8)),
-            "I32" => Ok(TType(TType::I32)),
+            "F16" => Ok(TensorType::F16(0)),
+            "F32" => Ok(TensorType::F32(0)),
+            "U8"  => Ok(TensorType::U8(0)),
+            "I32" => Ok(TensorType::I32(0)),
             _ => Err(()),
         }
         .map_err(|_| Error::InvalidParameter("invalid 'tensor_type'".to_string()))?;
@@ -67,7 +79,7 @@ pub fn get_default_inference_result(ml_error: Option<MlError>) -> InferenceOutpu
     InferenceOutput {
         result: get_result_status(ml_error),
         tensor: Tensor {
-            tensor_type: TensorType { ttype: 0 },
+            tensor_type: TensorType::F32(0),
             dimensions: vec![],
             data: vec![],
         },


### PR DESCRIPTION
enums (generated to bare numbers) are replaced by unions in TensorType and MlError